### PR TITLE
Fix #1 where error occurs when trying to read 2nd measurement in m…

### DIFF
--- a/twix/meas.py
+++ b/twix/meas.py
@@ -1047,23 +1047,16 @@ class MeasFile(object):
                 assert version == 2
             version = 2
             (n_meas,) = struct.unpack('<I', self._src_file.read(4))
-            for meas_idx in range(n_meas):
-                (meas_id,
-                 file_id,
-                 offset,
-                 length,
-                 patient,
-                 protocol) = struct.unpack('<2I2Q64s64s',
-                                           self._src_file.read(152))
-                patient = patient.rstrip(b'\0')
-                protocol = protocol.rstrip(b'\0')
+            meas_records = [struct.unpack('<2I2Q64s64s', self._src_file.read(152))
+                            for _ in range(n_meas)]
+            for meas_id, file_id, offset, length, patient, protocol in meas_records:
                 self._meas.append(Meas(self._src_file,
                                        offset,
                                        length,
                                        meas_id,
                                        file_id,
-                                       protocol,
-                                       patient,
+                                       protocol.rstrip(b'\0'),
+                                       patient.rstrip(b'\0'),
                                        version=version)
                                  )
 


### PR DESCRIPTION
…ulti-measurement twix file.

Problem was caused because each measurement _record_, listed at the beginning of the file, was being read and then immediately used to instantiate a `Meas` object. The instantiation of the `Meas` object caused the file location to move to that measurement. This meant the file location was no longer at the start of the next measurement _record_ when that next measurement _record_ was trying to be read.